### PR TITLE
fixed temporary return copy

### DIFF
--- a/core/ustring.h
+++ b/core/ustring.h
@@ -352,7 +352,7 @@ public:
 
 	_FORCE_INLINE_ String() {}
 	_FORCE_INLINE_ String(const String &p_str) { _cowdata._ref(p_str._cowdata); }
-	String operator=(const String &p_str) {
+	String &operator=(const String &p_str) {
 		_cowdata._ref(p_str._cowdata);
 		return *this;
 	}


### PR DESCRIPTION
Return string as reference in assignment operator, currently a copy is returned which will likely be a temporary copy.